### PR TITLE
remove the additional API for attendence of all courses and integrate with courses

### DIFF
--- a/routers/urls_router.py
+++ b/routers/urls_router.py
@@ -10,7 +10,6 @@ from utils.ims_api_utils import (
     update_bank_details,
     get_gpa_data,
     get_courses_data,
-    get_attendance_data,
     get_attendance_for_course,
     get_leave_requests,
     new_leave_request,
@@ -73,16 +72,6 @@ async def get_courses_api(current_user: dict = Depends(get_current_user)):
     if courses_data is None:
         raise HTTPException(status_code=404, detail="Courses not found")
     return courses_data
-
-
-@router.get("/attendance")
-async def get_attendance_api(current_user: dict = Depends(get_current_user)):
-    email = current_user["email"]
-    attendance_data = get_attendance_data(email)
-
-    if attendance_data is None:
-        raise HTTPException(status_code=404, detail="Attendance not found")
-    return attendance_data
 
 
 @router.get("/attendance/{course_id}")

--- a/utils/ims_api_utils.py
+++ b/utils/ims_api_utils.py
@@ -126,30 +126,8 @@ def get_courses_data(email: str):
     courses_return = api_return.content.decode().strip()
     courses_json = json.loads(courses_return)
 
-    return courses_json["Courses"]
-
-
-def get_attendance_data(email: str):
-    api_url = _make_url(COURSES_TYPE, COURSES_VARIABLE, email)
-
-    # Make API Call to get attendance data
-    api_return = requests.get(api_url)
-    if api_return.status_code != 200:
-        return None
-
-    courses_return = api_return.content.decode().strip()
-    courses_json = json.loads(courses_return)
-
-    attendances = courses_json["Attendance"]
-    courses = courses_json["Courses"]
-
-    attendance_data = {}
-    for course_id in courses:
-        course = courses[course_id]
-        attendance = attendances[course_id]
-        attendance_data[course_id] = {**course, **attendance}
-
-    return attendance_data
+    joint_courses = {**courses_json["Courses"], **courses_json["Attendance"]}
+    return joint_courses
 
 
 def get_attendance_for_course(email: str, course: str):

--- a/utils/ims_api_utils.py
+++ b/utils/ims_api_utils.py
@@ -126,7 +126,15 @@ def get_courses_data(email: str):
     courses_return = api_return.content.decode().strip()
     courses_json = json.loads(courses_return)
 
-    joint_courses = {**courses_json["Courses"], **courses_json["Attendance"]}
+    attendances = courses_json["Attendance"]
+    courses = courses_json["Courses"]
+
+    joint_courses = {}
+    for course_id in courses:
+        course = courses[course_id]
+        attendance = attendances[course_id]
+        joint_courses[course_id] = {**course, **attendance}
+
     return joint_courses
 
 


### PR DESCRIPTION
## Proposed Change 

- We are using the courses API as a dependance to many other APIs like, in leave missedExams in leaves.
Course list in transcript, Course list in attendance.
- The Courses API doesn't server any other purpose but to fullfill these dependencies.
- The current backend gives a seperate API for attendance_details which gives attendance details for all
courses, which is redundant and should be mixed with courseAPIs itself.